### PR TITLE
Update particle-network.adoc

### DIFF
--- a/components/tools/modules/ROOT/pages/wallets/particle-network.adoc
+++ b/components/tools/modules/ROOT/pages/wallets/particle-network.adoc
@@ -1,6 +1,6 @@
 = Particle Network
 
-Particle Network is an intent-centric, modular access layer of web3 applications. With Particle's Smart Wallet-as-a-Service, developers can curate an unparalleled user experience through modular and customizable EOA/AA embedded wallet components. Using MPC-TSS for key management, Particle can streamline user onboarding via familiar web2 accounts - such as Google accounts, email addresses, and phone numbers.
+[Particle Network](https://particle.network)'s Wallet Abstraction services enable universal, Web2-adjacent onboarding and interactions. Its core technology, [Smart Wallet-as-a-Service](https://blog.particle.network/announcing-our-smart-wallet-as-a-service-modular-stack-upgrading-waas-with-erc-4337) (WaaS) aims to onboard users into MPC-secured smart accounts supporting any chain. It also allows developers to offer an improved user experience through modular, fully customizable EOA/AA embedded wallets. Particle supports its Smart Wallet-as-a-Service through a Modular L1 powering chain abstraction, acting as a settlement layer across chains for a seamless multi-chain experience.
 
 For more information and support, see <https://docs.particle.network>, <https://blog.particle.network>, and <https://particle.network>
 


### PR DESCRIPTION
This PR applies a minor update to the page covering Particle Network (a social login and AA provider on SKALE) to shift around the opening blurb detailing Particle.

Particle Network is undergoing a slight rebranding, so this PR accounts for it with new positioning surrounding its placement and utility within the SKALE ecosystem.